### PR TITLE
app.yml:  use correct variable name

### DIFF
--- a/templates/containers/app.yml.j2
+++ b/templates/containers/app.yml.j2
@@ -14,7 +14,7 @@
 # This is configurable by amending the params in this file
 
 templates:
-{% for template in templates %}
+{% for template in discourse_templates %}
   - "templates/{{ template}}.template.yml"
 {% endfor %}
 ## which TCP/IP ports should this container expose?


### PR DESCRIPTION
Align variable names for the discourse template list: in `defaults/main.yml` it's `discourse_templates` while in the `templates/containers/app.yml.j2` it was `templates`.